### PR TITLE
Inclusão site via rápida

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,7 @@ Seu nome será inserido na lista de contribuidores após a aprovação do PR, at
 | [Universo Programado](https://www.youtube.com/channel/UCf_kacKyoRRUP0nM3obzFbg)                                                                | YouTube                     | Não         | pt-BR    |
 | [Universo Discreto](https://www.youtube.com/c/UniversoDiscreto/videos)                                                                         | Curso/Youtube                      | Não         | PT-BR    |
 | [URI Online Judge](https://www.urionlinejudge.com.br/judge/pt/login)                                                                           | Desafios                    | Não         | PT-BR    |
+| [Via rapida](http://www.viarapida.sp.gov.br/trilhas-sp-tech)                                                                                   | Site                     | Sim         | PT-BR    |
 | [Veduca](https://www.youtube.com/channel/UCJ-RnyVCbsTzADE4S7SSE3w/playlists)                                                                   | Youtube                     | Não         | PT-BR    |
 | [Vim para Noobs](https://leanpub.com/vimparanoobs)                                                                                             | Livro                       | Não         | PT-BR    |
 | [Waldemar Neto Dev Lab](https://www.youtube.com/user/waldemaneto)                                                                              | Youtube                     | Não         | PT-BR    |


### PR DESCRIPTION
Inclusão do site Via rápida - trilhas-sp-tech que oferecem cursos online de ciência de dados e desenvolvedor web.

http://www.viarapida.sp.gov.br/trilhas-sp-tech