### PR TITLE
Correção dos links dos canais do Matheus Battisti e da Michelli Brito. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,10 +181,10 @@ Seu nome será inserido na lista de contribuidores após a aprovação do PR, at
 | [Lucas Montano](https://www.youtube.com/channel/UCyHOBY6IDZF9zOKJPou2Rgg)                                                                      | Youtube                     | Não         | PT-BR    |
 | [Manu Codes](https://www.youtube.com/c/ManuCodes)                                                                                              | Youtube                     | Não         | PT-PT    |
 | [Maratona Kubernetes](https://www.youtube.com/playlist?list=PLB1hpnUGshULerdlzMknMLrHI810xIBJv&origin=CursosErickWendel)                       | Youtube                     | Nao         | PT-BR    |
-| [Matheus Battisti - Hora de Codar](https://www.youtube.com/channel/UC2WbG8UgpPaLcFSNJYwtPow)                                                   | Youtube                     | Nao         | PT-BR    |
+| [Matheus Battisti - Hora de Codar](https://www.youtube.com/channel/UCDoFiMhpOnLFq1uG4RL4xag)                                                   | Youtube                     | Nao         | PT-BR    |
 | [Melardev](https://www.youtube.com/channel/UCnG6_dkoHVz71JvzB_3v1rw)                                                   | Youtube                     | Nao         | EN/ES   |
 | [Meetanços](https://www.youtube.com/channel/UCtbW-YwuCvbM1TTlQdC7YOA)                                                   | Youtube                     | Nao         | PT-BR    |
-| [Michelli Brito](https://www.youtube.com/channel/UCDoFiMhpOnLFq1uG4RL4xag)                                                                     | Youtube                     | Nao         | PT-BR    |
+| [Michelli Brito](https://www.youtube.com/channel/UC2WbG8UgpPaLcFSNJYwtPow)                                                                     | Youtube                     | Nao         | PT-BR    |
 | [Microsoft Hyper-V Essentials](https://solyd.com.br/treinamentos/microsoft-hyper-v-essentials/)                                                | Curso/Youtube               | Sim         | PT-BR    |
 | [Microsoft Learn](https://docs.microsoft.com/pt-br/learn/)                                                                                     | Cursos                      | Não         | PT/EN    |
 | [Minerando Dados](https://www.youtube.com/channel/UCZ8gRCp3vixlGVAtplCDd5Q)                                                                    | Youtube                     | Nao         | PT-BR    |


### PR DESCRIPTION
Esse PR corrige os links dos canais do Matheus Battisti e da Michelli Brito que estão trocados. Ou seja, ao clicar no link do Matheus Battisti, leva ao canal da Michelli Brito e vice-versa.